### PR TITLE
Zero upper bits of vector that contains the initial scalar CRC

### DIFF
--- a/generate.c
+++ b/generate.c
@@ -959,7 +959,7 @@ static void emit_xor_scalar_into_vector(sbuf_t* b, const char* scalar, const cha
     put_fmt(b, "%s = _mm_xor_si128(_mm_cvtsi32_si128(%s), %s);\n", vector, scalar, vector);
     break;
   case ISA_AVX512_VPCLMULQDQ:
-    put_fmt(b, "%s = _mm512_xor_si512(_mm512_castsi128_si512(_mm_cvtsi32_si128(%s)), %s);\n", vector, scalar, vector);
+    put_fmt(b, "%s = _mm512_xor_si512(_mm512_zextsi128_si512(_mm_cvtsi32_si128(%s)), %s);\n", vector, scalar, vector);
     break;
   default:
     FATAL_ISA();


### PR DESCRIPTION
According to the Intel intrinsics manual for
_mm512_castsi128_si512:

"Cast vector of type __m128i to type __m512i;
the upper 384 bits of the result are undefined."

On at least clang 18 and 19 at optimization level -O0,
this can lead to incorrect CRC calculation.

Fix by replacing _mm512_castsi128_si512 with
_mm512_zextsi128_si512.

Author: John Naylor <john.naylor@postgresql.org>
Diagnosed-by: Nathan Bossart <nathan@postgresql.org>
Diagnosed-by: Raghuveer Devulapalli <raghuveer.devulapalli@intel.com>